### PR TITLE
Example of filters undefined in vento templates

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -6,4 +6,6 @@ const site = lume({
 import vento from 'lume/plugins/vento.ts';
 site.use(vento());
 
+site.filter("t", (label) => label);
+
 await site.build();

--- a/src/index.vto
+++ b/src/index.vto
@@ -5,3 +5,6 @@ title: This is a title
 ---
 
 {{ title }}
+
+<!-- This line will cause an error stating that `t` can't be found. -->
+{{ t("my_label") }}


### PR DESCRIPTION
When defining a filter on the `site`, I can't seem to call the filter inside a vento template.

This pull requests's diff produces the following error:

```console
$ deno task serve
Task serve deno run --allow-env=LUME_ENV --allow-read=. --allow-write=./_site --allow-net=0.0.0.0:8000 ./scripts/serve.ts
error: Uncaught (in promise) Error: Error rendering this page
            throw new Exception("Error rendering this page", { cause, page });
                  ^
    at https://deno.land/x/lume@v1.18.4/core/renderer.ts:133:19
    at eventLoopTick (ext:core/01_core.js:183:11)
    at async Promise.all (index 0)
    at async concurrent (https://deno.land/x/lume@v1.18.4/core/utils.ts:165:3)
    at async Renderer.renderPages (https://deno.land/x/lume@v1.18.4/core/renderer.ts:119:7)
    at async Site.#buildPages (https://deno.land/x/lume@v1.18.4/core/site.ts:615:5)
    at async Site.build (https://deno.land/x/lume@v1.18.4/core/site.ts:530:9)
    at async file:///Users/leighmcculloch/Code/lumeexample/scripts/build.ts:11:1
Caused by: Error: Error compiling template: /index.vto
    at Environment.compile (https://deno.land/x/vento@v0.6.0/src/environment.ts:107:13)
    at Environment.runString (https://deno.land/x/vento@v0.6.0/src/environment.ts:64:29)
    at VentoEngine.render (https://deno.land/x/lume@v1.18.4/plugins/vento.ts:64:24)
    at Renderer.render (https://deno.land/x/lume@v1.18.4/core/renderer.ts:198:32)
    at Renderer.#renderPage (https://deno.land/x/lume@v1.18.4/core/renderer.ts:224:23)
    at https://deno.land/x/lume@v1.18.4/core/renderer.ts:123:51
    at concurrent (https://deno.land/x/lume@v1.18.4/core/utils.ts:154:33)
    at eventLoopTick (ext:core/01_core.js:183:11)
    at async Renderer.renderPages (https://deno.land/x/lume@v1.18.4/core/renderer.ts:119:7)
    at async Site.#buildPages (https://deno.land/x/lume@v1.18.4/core/site.ts:615:5)
Caused by: SyntaxError: Unexpected identifier 't'
    at new Function (<anonymous>)
    at Environment.compile (https://deno.land/x/vento@v0.6.0/src/environment.ts:82:27)
    at Environment.runString (https://deno.land/x/vento@v0.6.0/src/environment.ts:64:29)
    at VentoEngine.render (https://deno.land/x/lume@v1.18.4/plugins/vento.ts:64:24)
    at Renderer.render (https://deno.land/x/lume@v1.18.4/core/renderer.ts:198:32)
    at Renderer.#renderPage (https://deno.land/x/lume@v1.18.4/core/renderer.ts:224:23)
    at https://deno.land/x/lume@v1.18.4/core/renderer.ts:123:51
    at concurrent (https://deno.land/x/lume@v1.18.4/core/utils.ts:154:33)
    at eventLoopTick (ext:core/01_core.js:183:11)
    at async Renderer.renderPages (https://deno.land/x/lume@v1.18.4/core/renderer.ts:119:7)
```